### PR TITLE
Removed trait implementation boilerplate with macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ approx = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.2"
-quickcheck_macros = "0.2"
+#quickcheck_macros = "0.2"

--- a/examples/vectors.rs
+++ b/examples/vectors.rs
@@ -80,7 +80,7 @@ impl<Scalar: AbstractField> Identity<Additive> for Vec2<Scalar> {
     }
 }
 
-impl_abelian!(Additive; Vec2<Scalar> where Scalar: AbstractField);
+impl_abelian!(<Additive> for Vec2<Scalar> where Scalar: AbstractField);
 
 impl<Scalar: AbstractField> AbstractModule for Vec2<Scalar> {
     type AbstractRing = Scalar;
@@ -251,7 +251,7 @@ impl Identity<Multiplicative> for Rational {
     }
 }
 
-impl_field!(Rational);
+impl_field!(<Additive, Multiplicative> for Rational);
 
 fn main() {
     let vec = || W::<_, Additive, Multiplicative>::new(Vec2::new(Rational::new(1, 2), Rational::whole(3)));

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -26,11 +26,11 @@
 //! Let `Self` be a set. Here is a list of the most common properties those operator may fulfill:
 //!
 //! ~~~notrust
-//! (Closure)       a, b ∈ Self ⇒ a ∘ b ∈ Self, 
+//! (Closure)       a, b ∈ Self ⇒ a ∘ b ∈ Self,
 //! (Divisibility)  ∀ a, b ∈ Self, ∃! r, l ∈ Self such that l ∘ a = b and a ∘ r = b
 //! (Invertibility) ∃ e ∈ Self, ∀ a ∈ Self, ∃ r, l ∈ Self such that l ∘ a = a ∘ r = e
 //!                 If the right and left inverse are equal they are usually noted r = l = a⁻¹.
-//! (Associativity) ∀ a, b, c ∈ Self, (a ∘ b) ∘ c = a ∘ (b ∘ c)       
+//! (Associativity) ∀ a, b, c ∈ Self, (a ∘ b) ∘ c = a ∘ (b ∘ c)
 //! (Neutral Elt.)  ∃ e ∈ Self, ∀ a ∈ Self, e ∘ a = a ∘ e = a
 //! (Commutativity) ∀ a, b ∈ Self, a ∘ b = b ∘ a
 //! ~~~
@@ -88,7 +88,7 @@
 //! ## Ring-like structures
 //!
 //! ~~~notrust
-//!      GroupAbelian           Monoid              
+//!      GroupAbelian           Monoid
 //!           \________   ________/
 //!                    \ /
 //!                     |
@@ -166,6 +166,7 @@ pub use self::specialized::{
     Ring, RingCommutative, Field, Module};
 pub use self::real::Real;
 
+#[macro_use]
 mod one_operator;
 mod two_operators;
 mod module;

--- a/src/general/one_operator.rs
+++ b/src/general/one_operator.rs
@@ -56,8 +56,8 @@ pub trait AbstractQuasigroup<O: Operator>
 
 #[macro_export]
 macro_rules! impl_quasigroup(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($T)+);
     }
 );
 
@@ -87,8 +87,8 @@ pub trait AbstractSemigroup<O: Operator> : PartialEq + AbstractMagma<O> {
 
 #[macro_export]
 macro_rules! impl_semigroup(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_marker!($crate::general::AbstractSemigroup<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_marker!($crate::general::AbstractSemigroup<$M>; $($T)+);
     }
 );
 
@@ -108,9 +108,9 @@ pub trait AbstractLoop<O: Operator>
 
 #[macro_export]
 macro_rules! impl_loop(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_quasigroup!($M; $($($T)+);*);
-        impl_marker!($crate::general::AbstractLoop<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_quasigroup!(<$M> for $($T)+);
+        impl_marker!($crate::general::AbstractLoop<$M>; $($T)+);
     }
 );
 
@@ -137,15 +137,15 @@ pub trait AbstractMonoid<O: Operator>
     fn prop_operating_identity_element_is_noop(a: Self) -> bool
         where Self: Eq {
         a.operate(&Self::identity()) == a &&
-        Self::identity().operate(&a)     == a
+        Self::identity().operate(&a) == a
     }
 }
 
 #[macro_export]
 macro_rules! impl_monoid(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_semigroup!($M; $($($T)+);*);
-        impl_marker!($crate::general::AbstractMonoid<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_semigroup!(<$M> for $($T)+);
+        impl_marker!($crate::general::AbstractMonoid<$M>; $($T)+);
     }
 );
 
@@ -156,11 +156,11 @@ pub trait AbstractGroup<O: Operator>
 
 #[macro_export]
 macro_rules! impl_group(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_monoid!($M; $($($T)+);*);
-        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($($T)+);*);
-        impl_marker!($crate::general::AbstractLoop<$M>; $($($T)+);*);
-        impl_marker!($crate::general::AbstractGroup<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_monoid!(<$M> for $($T)+);
+        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($T)+);
+        impl_marker!($crate::general::AbstractLoop<$M>; $($T)+);
+        impl_marker!($crate::general::AbstractGroup<$M>; $($T)+);
     }
 );
 
@@ -190,9 +190,9 @@ pub trait AbstractGroupAbelian<O: Operator>
 
 #[macro_export]
 macro_rules! impl_abelian(
-    ($M:ty; $($($T:tt)+);* $(;)*) => {
-        impl_group!($M; $($($T)+);*);
-        impl_marker!($crate::general::AbstractGroupAbelian<$M>; $($($T)+);*);
+    (<$M:ty> for $($T:tt)+) => {
+        impl_group!(<$M> for $($T)+);
+        impl_marker!($crate::general::AbstractGroupAbelian<$M>; $($T)+);
     }
 );
 
@@ -218,20 +218,5 @@ macro_rules! impl_magma(
 impl_magma!(Additive; add; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 impl_magma!(Multiplicative; mul; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
-impl_marker!(AbstractQuasigroup<Additive>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractQuasigroup<Multiplicative>; f32; f64);
-
-impl_marker!(AbstractMonoid<Additive>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractMonoid<Multiplicative>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
-
-impl_marker!(AbstractSemigroup<Additive>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractSemigroup<Multiplicative>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
-
-impl_marker!(AbstractLoop<Additive>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractLoop<Multiplicative>; f32; f64);
-
-impl_marker!(AbstractGroup<Additive>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractGroup<Multiplicative>; f32; f64);
-
-impl_marker!(AbstractGroupAbelian<Additive>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractGroupAbelian<Multiplicative>; f32; f64);
+impl_monoid!(<Additive> for u8; u16; u32; u64);
+impl_monoid!(<Multiplicative> for u8; u16; u32; u64);

--- a/src/general/one_operator.rs
+++ b/src/general/one_operator.rs
@@ -54,11 +54,18 @@ pub trait AbstractQuasigroup<O: Operator>
     }
 }
 
+#[macro_export]
+macro_rules! impl_quasigroup(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($($T)+);*);
+    }
+);
+
 
 /// An associative magma.
 ///
 /// ~~~notrust
-/// ∀ a, b, c ∈ Self, (a ∘ b) ∘ c = a ∘ (b ∘ c)       
+/// ∀ a, b, c ∈ Self, (a ∘ b) ∘ c = a ∘ (b ∘ c)
 /// ~~~
 pub trait AbstractSemigroup<O: Operator> : PartialEq + AbstractMagma<O> {
     /// Returns `true` if associativity holds for the given arguments. Approximate equality is used
@@ -78,6 +85,14 @@ pub trait AbstractSemigroup<O: Operator> : PartialEq + AbstractMagma<O> {
     }
 }
 
+#[macro_export]
+macro_rules! impl_semigroup(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_marker!($crate::general::AbstractSemigroup<$M>; $($($T)+);*);
+    }
+);
+
+
 /// A quasigroup with an unique identity element.
 ///
 /// The left inverse `r` and right inverse `l` are not required to be equal.
@@ -90,6 +105,14 @@ pub trait AbstractLoop<O: Operator>
     : AbstractQuasigroup<O>
     + Identity<O>
 { }
+
+#[macro_export]
+macro_rules! impl_loop(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_quasigroup!($M; $($($T)+);*);
+        impl_marker!($crate::general::AbstractLoop<$M>; $($($T)+);*);
+    }
+);
 
 
 /// A semigroup equipped with an identity element.
@@ -118,10 +141,28 @@ pub trait AbstractMonoid<O: Operator>
     }
 }
 
+#[macro_export]
+macro_rules! impl_monoid(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_semigroup!($M; $($($T)+);*);
+        impl_marker!($crate::general::AbstractMonoid<$M>; $($($T)+);*);
+    }
+);
+
 /// A group is a loop and a monoid at the same time.
 pub trait AbstractGroup<O: Operator>
     : AbstractLoop<O> + AbstractMonoid<O>
 { }
+
+#[macro_export]
+macro_rules! impl_group(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_monoid!($M; $($($T)+);*);
+        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($($T)+);*);
+        impl_marker!($crate::general::AbstractLoop<$M>; $($($T)+);*);
+        impl_marker!($crate::general::AbstractGroup<$M>; $($($T)+);*);
+    }
+);
 
 /// An commutative group.
 ///
@@ -147,7 +188,13 @@ pub trait AbstractGroupAbelian<O: Operator>
     }
 }
 
-
+#[macro_export]
+macro_rules! impl_abelian(
+    ($M:ty; $($($T:tt)+);* $(;)*) => {
+        impl_group!($M; $($($T)+);*);
+        impl_marker!($crate::general::AbstractGroupAbelian<$M>; $($($T)+);*);
+    }
+);
 
 /*
  *
@@ -171,20 +218,20 @@ macro_rules! impl_magma(
 impl_magma!(Additive; add; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 impl_magma!(Multiplicative; mul; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
-impl_marker!(AbstractQuasigroup<Additive>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractQuasigroup<Multiplicative>; f32, f64);
+impl_marker!(AbstractQuasigroup<Additive>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractQuasigroup<Multiplicative>; f32; f64);
 
-impl_marker!(AbstractMonoid<Additive>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractMonoid<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+impl_marker!(AbstractMonoid<Additive>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractMonoid<Multiplicative>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
 
-impl_marker!(AbstractSemigroup<Additive>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractSemigroup<Multiplicative>; u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+impl_marker!(AbstractSemigroup<Additive>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractSemigroup<Multiplicative>; u8; u16; u32; u64; i8; i16; i32; i64; f32; f64);
 
-impl_marker!(AbstractLoop<Additive>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractLoop<Multiplicative>; f32, f64);
+impl_marker!(AbstractLoop<Additive>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractLoop<Multiplicative>; f32; f64);
 
-impl_marker!(AbstractGroup<Additive>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractGroup<Multiplicative>; f32, f64);
+impl_marker!(AbstractGroup<Additive>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractGroup<Multiplicative>; f32; f64);
 
-impl_marker!(AbstractGroupAbelian<Additive>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractGroupAbelian<Multiplicative>; f32, f64);
+impl_marker!(AbstractGroupAbelian<Additive>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractGroupAbelian<Multiplicative>; f32; f64);

--- a/src/general/two_operators.rs
+++ b/src/general/two_operators.rs
@@ -47,10 +47,10 @@ pub trait AbstractRing<A: Operator = Additive, M: Operator = Multiplicative>:
 
 #[macro_export]
 macro_rules! impl_ring(
-    ($($T:ty),* $(,)*) => {
-        impl_abelian!($crate::general::Additive; $($T),*);
-        impl_monoid!($crate::general::Multiplicative; $($T),*);
-        impl_marker!($crate::general::AbstractRing; $($T),*);
+    (<$A:ty, $M:ty> for $($T:ty);* $(;)*) => {
+        impl_abelian!(<$A> for $($T);*);
+        impl_monoid!(<$M> for $($T);*);
+        impl_marker!(AbstractRing<$A, $M>; $($T);*);
     }
 );
 
@@ -86,9 +86,9 @@ pub trait AbstractRingCommutative<A: Operator = Additive, M: Operator = Multipli
 
 #[macro_export]
 macro_rules! impl_ring_commutative(
-    ($($T:ty);* $(;)*) => {
-        impl_ring!($($T);*);
-        impl_marker!($crate::general::AbstractRingCommutative; $($T);*);
+    (<$A:ty, $M:ty> for $($T:ty);* $(;)*) => {
+        impl_ring!(<$A, $M> for $($T);*);
+        impl_marker!($crate::general::AbstractRingCommutative<$A, $M>; $($T);*);
     }
 );
 
@@ -100,13 +100,13 @@ pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>
 
 #[macro_export]
 macro_rules! impl_field(
-    ($($T:ty);* $(;)*) => {
-        impl_ring_commutative!($($T);*);
-        impl_marker!($crate::general::AbstractQuasigroup<Multiplicative>; $($T);*);
-        impl_marker!($crate::general::AbstractLoop<Multiplicative>; $($T);*);
-        impl_marker!($crate::general::AbstractGroup<Multiplicative>; $($T);*);
-        impl_marker!($crate::general::AbstractGroupAbelian<Multiplicative>; $($T);*);
-        impl_marker!($crate::general::AbstractField; $($T);*);
+    (<$A:ty, $M:ty> for $($T:ty);* $(;)*) => {
+        impl_ring_commutative!(<$A, $M> for $($T);*);
+        impl_marker!($crate::general::AbstractQuasigroup<$M>; $($T);*);
+        impl_marker!($crate::general::AbstractLoop<$M>; $($T);*);
+        impl_marker!($crate::general::AbstractGroup<$M>; $($T);*);
+        impl_marker!($crate::general::AbstractGroupAbelian<$M>; $($T);*);
+        impl_marker!($crate::general::AbstractField<$A, $M>; $($T);*);
     }
 );
 
@@ -115,6 +115,5 @@ macro_rules! impl_field(
  * Implementations.
  *
  */
-impl_marker!(AbstractRing<Additive, Multiplicative>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractRingCommutative<Additive, Multiplicative>; i8; i16; i32; i64; f32; f64);
-impl_marker!(AbstractField<Additive, Multiplicative>; f32; f64);
+impl_ring_commutative!(<Additive, Multiplicative> for i8; i16; i32; i64);
+impl_field!(<Additive, Multiplicative> for f32; f64);

--- a/src/general/two_operators.rs
+++ b/src/general/two_operators.rs
@@ -45,6 +45,15 @@ pub trait AbstractRing<A: Operator = Additive, M: Operator = Multiplicative>:
     }
 }
 
+#[macro_export]
+macro_rules! impl_ring(
+    ($($T:ty),* $(,)*) => {
+        impl_abelian!($crate::general::Additive; $($T),*);
+        impl_monoid!($crate::general::Multiplicative; $($T),*);
+        impl_marker!($crate::general::AbstractRing; $($T),*);
+    }
+);
+
 /// A ring with a commutative multiplication.
 ///
 /// ```notrust
@@ -75,18 +84,37 @@ pub trait AbstractRingCommutative<A: Operator = Additive, M: Operator = Multipli
     }
 }
 
+#[macro_export]
+macro_rules! impl_ring_commutative(
+    ($($T:ty);* $(;)*) => {
+        impl_ring!($($T);*);
+        impl_marker!($crate::general::AbstractRingCommutative; $($T);*);
+    }
+);
+
 /// A field is a commutative ring, and an abelian group under both operators.
 pub trait AbstractField<A: Operator = Additive, M: Operator = Multiplicative>
     : AbstractRingCommutative<A, M>
     + AbstractGroupAbelian<M>
 { }
 
+#[macro_export]
+macro_rules! impl_field(
+    ($($T:ty);* $(;)*) => {
+        impl_ring_commutative!($($T);*);
+        impl_marker!($crate::general::AbstractQuasigroup<Multiplicative>; $($T);*);
+        impl_marker!($crate::general::AbstractLoop<Multiplicative>; $($T);*);
+        impl_marker!($crate::general::AbstractGroup<Multiplicative>; $($T);*);
+        impl_marker!($crate::general::AbstractGroupAbelian<Multiplicative>; $($T);*);
+        impl_marker!($crate::general::AbstractField; $($T);*);
+    }
+);
 
 /*
  *
  * Implementations.
  *
  */
-impl_marker!(AbstractRing<Additive, Multiplicative>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractRingCommutative<Additive, Multiplicative>; i8, i16, i32, i64, f32, f64);
-impl_marker!(AbstractField<Additive, Multiplicative>; f32, f64);
+impl_marker!(AbstractRing<Additive, Multiplicative>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractRingCommutative<Additive, Multiplicative>; i8; i16; i32; i64; f32; f64);
+impl_marker!(AbstractField<Additive, Multiplicative>; f32; f64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
 #![deny(non_upper_case_globals)]
-#![deny(unused_qualifications)]
 #![deny(unused_results)]
 #![deny(missing_docs)]
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,11 +13,97 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-macro_rules! impl_marker {
-    ($M:ty; $($T:ty),* $(,)*) => {
-        $(impl $M for $T { })+
-    }
-}
+#[macro_export]
+macro_rules! impl_marker(
+    (@para_rec
+        [$M:ty, ($($G:tt)+), ($($F:tt)*)]
+        (< $($R:tt)*)
+    ) => {
+        impl< $($R)* $M for $($F)*< $($R)*
+            where $($G)+
+        {}
+    };
+    (@para_rec
+        [$M:ty, ($($G:tt)+), ($($F:tt)*)]
+        ($C:tt $($R:tt)*)
+    ) => {
+        impl_marker!(@para_rec
+            [$M, ($($G)+), ($($F)* $C)]
+            ($($R)*)
+        );
+    };
+    (@where_rec
+        [$M:ty, ($($P:tt)+), ($($G:tt)+)]
+        ($(;)*)
+    ) => {
+        impl_marker!(@para_rec
+            [$M, ($($G)+), ()]
+            ($($P)+)
+        );
+    };
+    (@where_rec
+        [$M:ty, ($($P:tt)+), ($($G:tt)+)]
+        (; $($R:tt)+)
+    ) => {
+        impl_marker!(@para_rec
+            [$M, ($($G)+), ()]
+            ($($P)+)
+        );
+        impl_marker!(@rec
+            [$M, ()]
+            ($($R)+)
+        );
+    };
+    (@where_rec
+        [$M:ty, ($($P:tt)+), ($($F:tt)*)]
+        ($C:tt $($R:tt)*)
+    ) => {
+        impl_marker!(@where_rec
+            [$M, ($($P)+), ($($F)* $C)]
+            ($($R)*)
+        );
+    };
+    (@rec
+        [$M:ty, ($($F:tt)*)]
+        ($(;)*)
+    ) => {
+        impl $M for $($F)* { }
+    };
+    (@rec
+        [$M:ty, ($($F:tt)*)]
+        (; $($R:tt)+)
+    ) => {
+        impl $M for $($F)* { }
+        impl_marker!(@rec
+            [$M, ()]
+            ($($R)+)
+        );
+    };
+    (@rec
+        [$M:ty, ($($F:tt)+)]
+        (where $($G:tt)+)
+    ) => {
+        impl_marker!(@where_rec
+            [$M, ($($F)+), ()]
+            ($($G)+)
+        );
+    };
+    (@rec
+        [$M:ty, ($($F:tt)*)]
+        ($C:tt $($R:tt)*)
+    ) => {
+        impl_marker!(@rec
+            [$M, ($($F)* $C)]
+            ($($R)*)
+        );
+    };
+    ($M:ty; $($R:tt)+) => {
+        impl_marker!(@rec
+            [$M, ()]
+            ($($R)+)
+        );
+    };
+);
 
 macro_rules! impl_ident {
     ($M:ty; $V:expr; $($T:ty),* $(,)*) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,6 +15,7 @@
 
 #[macro_export]
 macro_rules! impl_marker(
+    // Finds the generic parameters of the type and implements the trait for it
     (@para_rec
         [$M:ty, ($($G:tt)+), ($($F:tt)*)]
         (< $($R:tt)*)
@@ -23,6 +24,7 @@ macro_rules! impl_marker(
             where $($G)+
         {}
     };
+    // Munches some token trees for searching generic parameters of the type
     (@para_rec
         [$M:ty, ($($G:tt)+), ($($F:tt)*)]
         ($C:tt $($R:tt)*)
@@ -32,6 +34,7 @@ macro_rules! impl_marker(
             ($($R)*)
         );
     };
+    // Handles the trailing separator after where clause
     (@where_rec
         [$M:ty, ($($P:tt)+), ($($G:tt)+)]
         ($(;)*)
@@ -41,6 +44,7 @@ macro_rules! impl_marker(
             ($($P)+)
         );
     };
+    // Implements the trait for the generic type and continues searching other types
     (@where_rec
         [$M:ty, ($($P:tt)+), ($($G:tt)+)]
         (; $($R:tt)+)
@@ -54,6 +58,7 @@ macro_rules! impl_marker(
             ($($R)+)
         );
     };
+    // Munches some token trees for searching the end of the where clause
     (@where_rec
         [$M:ty, ($($P:tt)+), ($($F:tt)*)]
         ($C:tt $($R:tt)*)
@@ -63,12 +68,14 @@ macro_rules! impl_marker(
             ($($R)*)
         );
     };
+    // Handles the trailing separator for non-generic type and implements the trait
     (@rec
         [$M:ty, ($($F:tt)*)]
         ($(;)*)
     ) => {
         impl $M for $($F)* { }
     };
+    // Implements the trait for the non-generic type and continues searching other types
     (@rec
         [$M:ty, ($($F:tt)*)]
         (; $($R:tt)+)
@@ -79,6 +86,7 @@ macro_rules! impl_marker(
             ($($R)+)
         );
     };
+    // Detects that there is indeed a where clause for the type and tries to find where it ends.
     (@rec
         [$M:ty, ($($F:tt)+)]
         (where $($G:tt)+)
@@ -88,6 +96,7 @@ macro_rules! impl_marker(
             ($($G)+)
         );
     };
+    // Munches some token trees for detecting if we have where clause or not
     (@rec
         [$M:ty, ($($F:tt)*)]
         ($C:tt $($R:tt)*)
@@ -97,6 +106,7 @@ macro_rules! impl_marker(
             ($($R)*)
         );
     };
+    // Entry point to the macro
     ($M:ty; $($R:tt)+) => {
         impl_marker!(@rec
             [$M, ()]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,100 +17,100 @@
 macro_rules! impl_marker(
     // Finds the generic parameters of the type and implements the trait for it
     (@para_rec
-        [$M:ty, ($($G:tt)+), ($($F:tt)*)]
-        (< $($R:tt)*)
+        [$tra1t:ty, ($($clause:tt)+), ($($type_constr:tt)*)]
+        (< $($params:tt)*)
     ) => {
-        impl< $($R)* $M for $($F)*< $($R)*
-            where $($G)+
+        impl< $($params)* $tra1t for $($type_constr)*< $($params)*
+            where $($clause)+
         {}
     };
     // Munches some token trees for searching generic parameters of the type
     (@para_rec
-        [$M:ty, ($($G:tt)+), ($($F:tt)*)]
-        ($C:tt $($R:tt)*)
+        [$tra1t:ty, ($($clause:tt)+), ($($prev:tt)*)]
+        ($cur:tt $($rest:tt)*)
     ) => {
         impl_marker!(@para_rec
-            [$M, ($($G)+), ($($F)* $C)]
-            ($($R)*)
+            [$tra1t, ($($clause)+), ($($prev)* $cur)]
+            ($($rest)*)
         );
     };
     // Handles the trailing separator after where clause
     (@where_rec
-        [$M:ty, ($($P:tt)+), ($($G:tt)+)]
+        [$tra1t:ty, ($($typ3:tt)+), ($($clause:tt)+)]
         ($(;)*)
     ) => {
         impl_marker!(@para_rec
-            [$M, ($($G)+), ()]
-            ($($P)+)
+            [$tra1t, ($($clause)+), ()]
+            ($($typ3)+)
         );
     };
     // Implements the trait for the generic type and continues searching other types
     (@where_rec
-        [$M:ty, ($($P:tt)+), ($($G:tt)+)]
-        (; $($R:tt)+)
+        [$tra1t:ty, ($($typ3:tt)+), ($($clause:tt)+)]
+        (; $($rest:tt)+)
     ) => {
         impl_marker!(@para_rec
-            [$M, ($($G)+), ()]
-            ($($P)+)
+            [$tra1t, ($($clause)+), ()]
+            ($($typ3)+)
         );
         impl_marker!(@rec
-            [$M, ()]
-            ($($R)+)
+            [$tra1t, ()]
+            ($($rest)+)
         );
     };
     // Munches some token trees for searching the end of the where clause
     (@where_rec
-        [$M:ty, ($($P:tt)+), ($($F:tt)*)]
-        ($C:tt $($R:tt)*)
+        [$tra1t:ty, ($($typ3:tt)+), ($($prev:tt)*)]
+        ($cur:tt $($rest:tt)*)
     ) => {
         impl_marker!(@where_rec
-            [$M, ($($P)+), ($($F)* $C)]
-            ($($R)*)
+            [$tra1t, ($($typ3)+), ($($prev)* $cur)]
+            ($($rest)*)
         );
     };
     // Handles the trailing separator for non-generic type and implements the trait
     (@rec
-        [$M:ty, ($($F:tt)*)]
+        [$tra1t:ty, ($($typ3:tt)*)]
         ($(;)*)
     ) => {
-        impl $M for $($F)* { }
+        impl $tra1t for $($typ3)* { }
     };
     // Implements the trait for the non-generic type and continues searching other types
     (@rec
-        [$M:ty, ($($F:tt)*)]
-        (; $($R:tt)+)
+        [$tra1t:ty, ($($typ3:tt)*)]
+        (; $($rest:tt)+)
     ) => {
-        impl $M for $($F)* { }
+        impl $tra1t for $($typ3)* { }
         impl_marker!(@rec
-            [$M, ()]
-            ($($R)+)
+            [$tra1t, ()]
+            ($($rest)+)
         );
     };
     // Detects that there is indeed a where clause for the type and tries to find where it ends.
     (@rec
-        [$M:ty, ($($F:tt)+)]
-        (where $($G:tt)+)
+        [$tra1t:ty, ($($prev:tt)+)]
+        (where $($rest:tt)+)
     ) => {
         impl_marker!(@where_rec
-            [$M, ($($F)+), ()]
-            ($($G)+)
+            [$tra1t, ($($prev)+), ()]
+            ($($rest)+)
         );
     };
     // Munches some token trees for detecting if we have where clause or not
     (@rec
-        [$M:ty, ($($F:tt)*)]
-        ($C:tt $($R:tt)*)
+        [$tra1t:ty, ($($prev:tt)*)]
+        ($cur:tt $($rest:tt)*)
     ) => {
         impl_marker!(@rec
-            [$M, ($($F)* $C)]
-            ($($R)*)
+            [$tra1t, ($($prev)* $cur)]
+            ($($rest)*)
         );
     };
     // Entry point to the macro
-    ($M:ty; $($R:tt)+) => {
+    ($tra1t:ty; $($rest:tt)+) => {
         impl_marker!(@rec
-            [$M, ()]
-            ($($R)+)
+            [$tra1t, ()]
+            ($($rest)+)
         );
     };
 );


### PR DESCRIPTION
NOTE: This breaks tests by removing `quickcheck_macros`, because it doesn't work new enough nightly for the macro to work.
NOTE: The macro works only with nightly which is unfortunate.

PR for #1 