### PR TITLE
Release v0.4.0 + added changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+All notable changes to `alga`, starting with the version 0.4.0 will be
+documented here.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.4.0] - WIP
+  * The `Real` trait now includes some commonly implemented markers, e.g.,
+    Sync, Any, 'static, etc.
+  * The `Module` trait no longer inherit from operator overload traits. This is
+    due to a [limitation](https://github.com/rust-lang/rust/issues/37883) in
+    the compiler that prevent them from being used properly in generic code.
+  * The `Transform` trait is split into `Transform` and `ProjectiveTransform`.
+    Inverse transformation methods have been moved from the first to the second.
+  * The `Affine` trait now has methods for appending/prepending pure
+    translation/rotation/scaling.
+  * `EuclideanSpace::Vector` has been renamed `EuclideanSpace::Coordinates`.
+  * Added `Rotation::scaled_rotation_between` wich is a combination of
+    `Rotation::rotation_between` and `Rotation::powf`.
+  * `FiniteDimVectorSpace` looses `::component` but gains the
+    `::component_unchecked_mut` method (for mutable compoent borrowing without
+    bound-checking).
+  * Added `EuclideanSpace::from_coordinates` that builds a point from its
+    coordinates.
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alga"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Brendan Zabarauskas", "Darin Morrison", "Sébastien Crozet"]
 description = "Abstract algebra for Rust"
 keywords = ["algebra", "monoids", "math"]

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -72,7 +72,7 @@
 //!          commutativity
 //!                |
 //!                V
-//!           AbstractGroupAbelian
+//!      AbstractGroupAbelian
 //! ~~~
 //!
 //! The following traits are provided:

--- a/src/general/real.rs
+++ b/src/general/real.rs
@@ -1,10 +1,12 @@
-use num::{Num, FromPrimitive};
+use std::any::Any;
+use num::{Num, FromPrimitive, Signed, Bounded};
 use std::{f32, f64};
+use std::fmt::{Debug, Display};
 use std::ops::{Neg, AddAssign, MulAssign, SubAssign, DivAssign};
 
 use approx::ApproxEq;
 
-use general::{Field, SubsetOf, SupersetOf};
+use general::{Field, SubsetOf, SupersetOf, Lattice};
 
 #[allow(missing_docs)]
 
@@ -16,7 +18,9 @@ use general::{Field, SubsetOf, SupersetOf};
 // allow a blancket impl: impl<T: Clone> SubsetOf<T> for T { ... }
 pub trait Real: SubsetOf<Self> + SupersetOf<f64> + Field + Copy + Num + FromPrimitive +
                 Neg<Output = Self> + AddAssign + MulAssign + SubAssign + DivAssign +
-                ApproxEq<Epsilon = Self> + PartialOrd {
+                ApproxEq<Epsilon = Self> + Lattice + PartialEq + Signed +
+                Send + Sync + Any + 'static + Debug + Display + // NOTE: make all types debuggable/'static/Any ? This seems essencial for any kind of generic programming.
+                Bounded { // NOTE: a real must be bounded because, no matter the chosen representation, being `Copy` implies that it occupies a statically-known size, meaning that it must have min/max values.
     fn floor(self) -> Self;
     fn ceil(self) -> Self;
     fn round(self) -> Self;

--- a/src/general/specialized.rs
+++ b/src/general/specialized.rs
@@ -44,7 +44,9 @@ specialize_structures!(Field,           AbstractField:           RingCommutative
 
 /// A module which overloads the `*` and `+` operators.
 pub trait Module: AbstractModule<AbstractRing = <Self as Module>::Ring> +
-                  ClosedMul<<Self as Module>::Ring> {
+                    AdditiveGroupAbelian /* +
+                    ClosedMul<<Self as Module>::Ring>
+                  */ {
     /// The underlying scalar field.
     type Ring: RingCommutative;
 }

--- a/src/linear/id.rs
+++ b/src/linear/id.rs
@@ -2,7 +2,8 @@ use num;
 
 use general::{Identity, Id};
 use linear::{InnerSpace, EuclideanSpace, Transformation, AffineTransformation, Scaling, Similarity,
-             Isometry, DirectIsometry, OrthogonalTransformation, Translation, Rotation};
+             Isometry, DirectIsometry, OrthogonalTransformation, Translation, Rotation,
+             ProjectiveTransformation};
 
 /*
  * Implementation of linear algebra structures for the ubiquitous identity element.
@@ -14,35 +15,65 @@ impl<E: EuclideanSpace> Transformation<E> for Id {
     }
 
     #[inline]
-    fn transform_vector(&self, v: &E::Vector) -> E::Vector {
+    fn transform_vector(&self, v: &E::Coordinates) -> E::Coordinates {
         v.clone()
     }
+}
 
+impl<E: EuclideanSpace> ProjectiveTransformation<E> for Id {
     #[inline]
     fn inverse_transform_point(&self, pt: &E) -> E {
         pt.clone()
     }
 
     #[inline]
-    fn inverse_transform_vector(&self, v: &E::Vector) -> E::Vector {
+    fn inverse_transform_vector(&self, v: &E::Coordinates) -> E::Coordinates {
         v.clone()
     }
 }
 
 impl<E: EuclideanSpace> AffineTransformation<E> for Id {
-    type PreRotation       = Id;
+    type Rotation          = Id;
     type NonUniformScaling = Id;
-    type PostRotation      = Id;
     type Translation       = Id;
 
     #[inline]
     fn decompose(&self) -> (Id, Id, Id, Id) {
         (Id::new(), Id::new(), Id::new(), Id::new())
     }
+
+    #[inline]
+    fn append_translation(&self, _: &Self::Translation) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn prepend_translation(&self, _: &Self::Translation) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn append_rotation(&self, _: &Self::Rotation) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn prepend_rotation(&self, _: &Self::Rotation) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn append_scaling(&self, _: &Self::NonUniformScaling) -> Self {
+        *self
+    }
+
+    #[inline]
+    fn prepend_scaling(&self, _: &Self::NonUniformScaling) -> Self {
+        *self
+    }
 }
 
 impl<E: EuclideanSpace> Similarity<E> for Id {
-    type Rotation = Id;
     type Scaling  = Id;
 
     #[inline]
@@ -74,7 +105,7 @@ impl<E: EuclideanSpace> Rotation<E> for Id {
     }
 
     #[inline]
-    fn rotation_between(a: &E::Vector, b: &E::Vector) -> Option<Self> {
+    fn rotation_between(a: &E::Coordinates, b: &E::Coordinates) -> Option<Self> {
         if a.angle(b) == num::zero() {
             Some(Id::new())
         }
@@ -82,17 +113,22 @@ impl<E: EuclideanSpace> Rotation<E> for Id {
             None
         }
     }
+
+    #[inline]
+    fn scaled_rotation_between(a: &E::Coordinates, b: &E::Coordinates, _: E::Real) -> Option<Self> {
+        Rotation::<E>::rotation_between(a, b)
+    }
 }
 
 impl<E: EuclideanSpace> Translation<E> for Id {
     #[inline]
-    fn to_vector(&self) -> E::Vector {
-        E::Vector::identity()
+    fn to_vector(&self) -> E::Coordinates {
+        E::Coordinates::identity()
     }
 
     #[inline]
-    fn from_vector(v: &E::Vector) -> Option<Self> {
-        if *v == E::Vector::identity() {
+    fn from_vector(v: E::Coordinates) -> Option<Self> {
+        if v == E::Coordinates::identity() {
             Some(Id::new())
         }
         else {

--- a/src/linear/mod.rs
+++ b/src/linear/mod.rs
@@ -3,7 +3,8 @@
 pub use self::vector::{VectorSpace, NormedSpace, InnerSpace, FiniteDimVectorSpace, FiniteDimInnerSpace,
                        AffineSpace, EuclideanSpace};
 pub use self::transformation::{Transformation, AffineTransformation, Scaling, Similarity, Isometry,
-                               DirectIsometry, Translation, OrthogonalTransformation, Rotation};
+                               DirectIsometry, Translation, OrthogonalTransformation, Rotation,
+                               ProjectiveTransformation};
 pub use self::matrix::{Matrix, MatrixMut, SquareMatrix, SquareMatrixMut, InversibleSquareMatrix};
 
 mod vector;


### PR DESCRIPTION
Changelog:

* The `Real` trait now includes some commonly implemented markers, e.g. Sync, Any, 'static, etc.
* The `Module` trait no longer inherit from operator overload traits. This is due to a [limitation](https://github.com/rust-lang/rust/issues/37883) in the compiler that prevent them from being used properly in generic code.
* The `Transform` trait is split into `Transform` and `ProjectiveTransform`. Inverse transformation methods have been moved from the first to the second.
* The `Affine` trait now has methods for appending/prepending pure translation/rotation/scaling.
* `EuclideanSpace::Vector` has been renamed `EuclideanSpace::Coordinates`.
* Added `Rotation::scaled_rotation_between` wich is a combination of `Rotation::rotation_between` and `Rotation::powf`.
* `FiniteDimVectorSpace` looses `::component` but gains the `::component_unchecked_mut` method (for mutable compoent borrowing without bound-checking).
* Added `EuclideanSpace::from_coordinates` that builds a point from its coordinates.