### PR TITLE
disable `rustc-serialize` for `wasm32-unknown-unknown` target

### DIFF
--- a/alga/Cargo.toml
+++ b/alga/Cargo.toml
@@ -15,7 +15,7 @@ name = "alga"
 
 [dependencies]
 num-traits  = "0.1"
-num-complex = "0.1"
+num-complex = { version = "0.1", default-features = false }
 approx      = "0.1"
 decimal     = { version = "1.0", optional = true }
 


### PR DESCRIPTION
When build `alga` for `wasm32-unknown-unknown` target, it failed on `rustc-serialize`, we may disable it by default.

> rust-lang-deprecated/rustc-serialize#190